### PR TITLE
Revert Ansible requirements to published collection versions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,6 +13,7 @@ exclude_paths:
   - playbooks/aws/results/*
   - playbooks/azure/results/*
   - .github/workflows/requirements.yml
+  - .ansible
 # parseable: true
 # quiet: true
 # strict: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,6 +4,6 @@ collections:
   - name: azure.azcollection
     version: 1.19.0
   - name: cisco.catalystwan
-    version: 0.3.3
+    version: 0.3.2
   - name: cisco.sdwan_deployment
-    version: 0.3.4
+    version: 0.3.3


### PR DESCRIPTION
# Pull Request summary:
This PR revert collections in requirements.yml to versions published in ansible galaxy

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
